### PR TITLE
feat(ci): sign, attest and tag images only after tests pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,15 @@ on:
         type: string
 
 jobs:
+  # Publishes images under ephemeral run-scoped tags only. Floating tags
+  # (latest/glibc/debug), signatures and attestations are applied by the
+  # promote job after the test job has passed, so an unscanned image is
+  # never reachable through a consumable tag.
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      id-token: write
     outputs:
       base-digest: ${{ steps.extract-digest.outputs.base-digest }}
       glibc-digest: ${{ steps.extract-digest.outputs.glibc-digest }}
@@ -29,11 +32,11 @@ jobs:
       has-changes: ${{ steps.compare.outputs.has-changes }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # When called by another workflow, use the ref it provides.
           # Otherwise, use the default ref for the event (e.g., main branch).
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
       - name: Get previous digest and SBOM from last successful run
         id: previous
         env:
@@ -169,8 +172,8 @@ jobs:
           fi
       - name: Install apko
         env:
-          APKO_VERSION: 1.2.8
-          APKO_SHA256: 66f0383c66d29f1ca40ff8b0c876579afed356fd157009ef16a20f41301b0ac5
+          APKO_VERSION: 1.2.25
+          APKO_SHA256: b5a480cfb32458f55d1f1513a902f6cdf7dc284b9e6fe9840abdbcebc3908d47
         run: |
           set -e
           tmp=$(mktemp -d)
@@ -182,34 +185,47 @@ jobs:
           sudo install -m 0755 "$tmp/apko_${APKO_VERSION}_linux_amd64/apko" /usr/local/bin/apko
           rm -rf "$tmp"
           apko version
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.0.6
-      - name: Build, publish, and sign images
+      - name: Build and publish images (ephemeral tags, unsigned)
         id: build
         env:
-          COSIGN_EXPERIMENTAL: '1'
           OCI_HOST: ghcr.io
           OCI_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
 
+          # Reproducible image timestamps tied to the commit, not epoch 0
+          # (epoch 0 trips freshness checks) and not wall clock (breaks
+          # byte-reproducibility).
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+          export SOURCE_DATE_EPOCH
+          echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
+
           echo "$GITHUB_TOKEN" | apko login "$OCI_HOST" -u "${{ github.actor }}" --password-stdin
 
           mkdir -p sbom-base sbom-glibc sbom-debug
 
-          echo "Building base image (latest)..."
-          base_digest=$(apko publish base.yaml "$OCI_HOST/$OCI_REPO" \
+          # Run-scoped tags keep unscanned images out of every consumable
+          # tag; the promote job moves latest/glibc/debug after tests pass.
+          EPHEMERAL_PREFIX="$OCI_HOST/$OCI_REPO:build-${{ github.run_id }}"
+          REVISION_ANNOTATION="org.opencontainers.image.revision:${{ github.sha }}"
+
+          echo "Building base image..."
+          base_digest=$(apko publish base.yaml "$EPHEMERAL_PREFIX-base" \
+            --lockfile base.lock.json \
+            --annotations "$REVISION_ANNOTATION" \
             --sbom-path=sbom-base)
 
           echo "Building glibc image..."
-          glibc_digest=$(apko publish glibc.yaml "$OCI_HOST/$OCI_REPO:glibc" \
+          glibc_digest=$(apko publish glibc.yaml "$EPHEMERAL_PREFIX-glibc" \
+            --lockfile glibc.lock.json \
+            --annotations "$REVISION_ANNOTATION" \
             --sbom-path=sbom-glibc)
 
           echo "Building debug image..."
-          debug_digest=$(apko publish debug.yaml "$OCI_HOST/$OCI_REPO:debug" \
+          debug_digest=$(apko publish debug.yaml "$EPHEMERAL_PREFIX-debug" \
+            --lockfile debug.lock.json \
+            --annotations "$REVISION_ANNOTATION" \
             --sbom-path=sbom-debug)
 
           mkdir -p sbom-output
@@ -229,16 +245,11 @@ jobs:
             fi
           done
 
-          echo "Signing base image..."
-          cosign sign --yes "$base_digest"
-          echo "Signing glibc image..."
-          cosign sign --yes "$glibc_digest"
-          echo "Signing debug image..."
-          cosign sign --yes "$debug_digest"
-
-          echo "$base_digest" > base-digest.txt
-          echo "$glibc_digest" > glibc-digest.txt
-          echo "$debug_digest" > debug-digest.txt
+          # Normalize to canonical repo@sha256 refs so the ephemeral tag
+          # never leaks into signatures, attestations, or release notes.
+          echo "$OCI_HOST/$OCI_REPO@${base_digest##*@}" > base-digest.txt
+          echo "$OCI_HOST/$OCI_REPO@${glibc_digest##*@}" > glibc-digest.txt
+          echo "$OCI_HOST/$OCI_REPO@${debug_digest##*@}" > debug-digest.txt
       - name: Extract digests
         id: extract-digest
         run: |
@@ -276,33 +287,33 @@ jobs:
           # Clean up temporary files
           rm -f base-digest.txt glibc-digest.txt debug-digest.txt
       - name: Upload current base digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previous-base-digest
           path: current-base-digest/digest.txt
           retention-days: 7
           overwrite: true
       - name: Upload current glibc digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previous-glibc-digest
           path: current-glibc-digest/digest.txt
           retention-days: 7
           overwrite: true
       - name: Upload current debug digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previous-debug-digest
           path: current-debug-digest/digest.txt
           retention-days: 7
           overwrite: true
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom-output/
       - name: Upload SBOM for future comparisons
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previous-sbom
           path: sbom-output/
@@ -320,19 +331,19 @@ jobs:
         variant: [base, glibc, debug]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: linux/arm64,linux/amd64
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Set test configuration
         id: test-config
         run: |
@@ -427,7 +438,7 @@ jobs:
             -e TEST_VAR="Hello from ${{ matrix.variant }} test" \
             test-app:arm64
       - name: Security scan with Trivy for ${{ matrix.variant }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.test-config.outputs.base-image }}
           format: table
@@ -435,16 +446,110 @@ jobs:
           ignore-unfixed: true
           vuln-type: os,library
           severity: CRITICAL,HIGH
+  # Runs only after tests (including the Trivy scan) pass: signs images,
+  # attaches SBOM and SLSA provenance attestations, then moves the floating
+  # tags. Skipped for PR validation runs.
+  promote:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+      - name: Install crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        with:
+          version: v0.21.5
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: sbom-output
+      - name: Sign images and attest SBOMs
+        env:
+          BASE_DIGEST: ${{ needs.build.outputs.base-digest }}
+          GLIBC_DIGEST: ${{ needs.build.outputs.glibc-digest }}
+          DEBUG_DIGEST: ${{ needs.build.outputs.debug-digest }}
+        run: |
+          set -e
+          for variant in base glibc debug; do
+            case "$variant" in
+              base) digest="$BASE_DIGEST" ;;
+              glibc) digest="$GLIBC_DIGEST" ;;
+              debug) digest="$DEBUG_DIGEST" ;;
+            esac
+            sbom="sbom-output/${variant}_sbom-index.spdx.json"
+            if [ ! -s "$sbom" ]; then
+              echo "ERROR: missing or empty SBOM predicate: $sbom"
+              exit 1
+            fi
+            echo "Signing $variant image..."
+            cosign sign --yes "$digest"
+            echo "Attesting SBOM for $variant image..."
+            cosign attest --yes --type spdxjson --predicate "$sbom" "$digest"
+          done
+      - name: Extract bare digests
+        id: digests
+        env:
+          BASE_DIGEST: ${{ needs.build.outputs.base-digest }}
+          GLIBC_DIGEST: ${{ needs.build.outputs.glibc-digest }}
+          DEBUG_DIGEST: ${{ needs.build.outputs.debug-digest }}
+        run: |
+          echo "base-sha=${BASE_DIGEST##*@}" >> $GITHUB_OUTPUT
+          echo "glibc-sha=${GLIBC_DIGEST##*@}" >> $GITHUB_OUTPUT
+          echo "debug-sha=${DEBUG_DIGEST##*@}" >> $GITHUB_OUTPUT
+      - name: Attest build provenance (base)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.digests.outputs.base-sha }}
+          push-to-registry: true
+      - name: Attest build provenance (glibc)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.digests.outputs.glibc-sha }}
+          push-to-registry: true
+      - name: Attest build provenance (debug)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.digests.outputs.debug-sha }}
+          push-to-registry: true
+      - name: Promote floating tags
+        env:
+          BASE_DIGEST: ${{ needs.build.outputs.base-digest }}
+          GLIBC_DIGEST: ${{ needs.build.outputs.glibc-digest }}
+          DEBUG_DIGEST: ${{ needs.build.outputs.debug-digest }}
+        run: |
+          set -e
+          crane tag "$BASE_DIGEST" "latest"
+          crane tag "$GLIBC_DIGEST" "glibc"
+          crane tag "$DEBUG_DIGEST" "debug"
+          echo "Promoted floating tags: latest, glibc, debug"
   release:
     if: (github.event_name == 'push' || github.event_name == 'schedule') && needs.build.outputs.has-changes == 'true'
-    needs: [build, test]
+    needs: [build, test, promote]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Generate release tag
         id: tag
         run: |
@@ -460,7 +565,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Generated tag: $TAG"
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom
           path: sbom-output
@@ -476,7 +581,7 @@ jobs:
           pip install requests
           python3 scripts/generate_changelog.py
       - name: Upload SBOM changelog artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-changelog
           path: |
@@ -497,18 +602,13 @@ jobs:
           set -e
 
           crane tag "$BASE_DIGEST" "$TAG"
-          crane tag "$BASE_DIGEST" "latest"
-
           crane tag "$GLIBC_DIGEST" "$TAG-glibc"
-          crane tag "$GLIBC_DIGEST" "glibc"
-
           crane tag "$DEBUG_DIGEST" "$TAG-debug"
-          crane tag "$DEBUG_DIGEST" "debug"
 
           echo "Successfully tagged images:"
-          echo "Base: $TAG, latest"
-          echo "glibc: $TAG-glibc, glibc"
-          echo "Debug: $TAG-debug, debug"
+          echo "Base: $TAG"
+          echo "glibc: $TAG-glibc"
+          echo "Debug: $TAG-debug"
       - name: Create release body
         run: |
           # Read the SBOM changelog
@@ -522,20 +622,20 @@ jobs:
           DEBUG_DIGEST="${{ needs.build.outputs.debug-digest }}"
           cat > release-body.md << RELEASE_EOF
           ## 🚀 Automated Release
-          This release includes all three image variants: base (musl), glibc, and debug.
+          This release includes all three image variants: base (static, no libc), glibc, and debug.
           $SBOM_CHANGELOG
 
           ### 📦 Container Images
-          **Base Image (Production - musl libc)**
+          **Base Image (Production - static, no libc)**
           - **Image**: \`ghcr.io/${REPO}:latest\`
           - **Tagged Version**: \`ghcr.io/${REPO}:${TAG}\`
           - **Digest**: \`${BASE_DIGEST}\`
-          
+
           **glibc Image (Production - GNU libc)**
           - **Image**: \`ghcr.io/${REPO}:glibc\`
           - **Tagged Version**: \`ghcr.io/${REPO}:${TAG}-glibc\`
           - **Digest**: \`${GLIBC_DIGEST}\`
-          
+
           **Debug Image (Development)**
           - **Image**: \`ghcr.io/${REPO}:debug\`
           - **Tagged Version**: \`ghcr.io/${REPO}:${TAG}-debug\`
@@ -560,6 +660,18 @@ jobs:
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com
           \`\`\`
 
+          Each image also carries a signed SPDX SBOM attestation and SLSA
+          build provenance:
+          \`\`\`bash
+          # SBOM attestation
+          cosign verify-attestation ${BASE_DIGEST} --type spdxjson \\
+            --certificate-identity=https://github.com/${REPO}/.github/workflows/build.yml@refs/heads/main \\
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+          # SLSA build provenance
+          gh attestation verify oci://${BASE_DIGEST} --repo ${REPO}
+          \`\`\`
+
           ### 📄 Software Bill of Materials (SBOM)
           SBOMs for all three images are attached to this release.
 
@@ -567,7 +679,7 @@ jobs:
           The debug image should **NEVER** be used in production as it includes debugging tools and runs as root.
           RELEASE_EOF
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Release ${{ steps.tag.outputs.tag }}
@@ -581,4 +693,3 @@ jobs:
           generate_release_notes: false
           draft: false
           prerelease: false
-  

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Approve and enable automerge for Dependabot PR
-        uses: fastify/github-action-merge-dependabot@v3
+        uses: fastify/github-action-merge-dependabot@73ec4cbb5e56df5591eae286972d5b2201ffe90f # v3.15.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           approve: true

--- a/.github/workflows/update-locks.yml
+++ b/.github/workflows/update-locks.yml
@@ -1,0 +1,72 @@
+name: Update Lockfiles
+
+# Regenerates the apko lockfiles daily (ahead of the 05:00 build) and opens
+# a PR when Wolfi package versions have moved. Builds always use the
+# committed lockfiles, so images stay reproducible; freshness arrives
+# through these PRs.
+#
+# Note: PRs opened with GITHUB_TOKEN do not trigger the PR validation
+# workflow. Re-run checks manually (close/reopen the PR or push to its
+# branch), or switch this workflow to a PAT/GitHub App token if unattended
+# merges are wanted.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-locks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install apko
+        env:
+          APKO_VERSION: 1.2.25
+          APKO_SHA256: b5a480cfb32458f55d1f1513a902f6cdf7dc284b9e6fe9840abdbcebc3908d47
+        run: |
+          set -e
+          tmp=$(mktemp -d)
+          apko_archive="apko_${APKO_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "https://github.com/chainguard-dev/apko/releases/download/v${APKO_VERSION}/${apko_archive}" \
+            -o "$tmp/${apko_archive}"
+          echo "${APKO_SHA256}  $tmp/${apko_archive}" | sha256sum -c -
+          tar -xzf "$tmp/${apko_archive}" -C "$tmp"
+          sudo install -m 0755 "$tmp/apko_${APKO_VERSION}_linux_amd64/apko" /usr/local/bin/apko
+          rm -rf "$tmp"
+          apko version
+      - name: Regenerate lockfiles
+        run: |
+          set -e
+          for cfg in base glibc debug; do
+            apko lock "$cfg.yaml" --output "$cfg.lock.json"
+          done
+      - name: Open PR if lockfiles changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          if git diff --quiet -- '*.lock.json'; then
+            echo "Lockfiles unchanged, nothing to do."
+            exit 0
+          fi
+          branch="chore/lock-bump-$(date +%Y%m%d)"
+          if git ls-remote --exit-code origin "refs/heads/$branch" > /dev/null 2>&1; then
+            echo "Branch $branch already exists, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add -- '*.lock.json'
+          git commit -m "chore(deps): bump apko lockfiles $(date +%Y-%m-%d)"
+          git push origin "$branch"
+          gh pr create \
+            --title "chore(deps): bump apko lockfiles $(date +%Y-%m-%d)" \
+            --body "Automated Wolfi package refresh via \`apko lock\`. Diff shows exact package version changes." \
+            --label dependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository builds, updates, and secures multi-arch (currently only `x86_64` and `arm64`) **distroless Docker base images**. Three variants are published to GitHub Container Registry (GHCR) at `ghcr.io/taihen/base-image`:
 
-- **Base image** (`:latest`) - Minimal distroless image with musl libc
+- **Base image** (`:latest`) - Minimal distroless image with no libc, for statically-linked binaries
 - **glibc image** (`:glibc`) - Includes GNU libc for better compatibility  
 - **Debug image** (`:debug`) - Development variant with shell and debugging tools
 
@@ -20,7 +20,7 @@ Curious about distroless, checkout my [blog post](https://taihen.org/posts/distr
 
 Modern containerized applications face increasing security threats and compliance requirements. Traditional base images often include unnecessary packages, tools, and potential vulnerabilities that expand your attack surface. A secure and simple base image is essential because:
 
-- **Reduced Attack Surface**: By including only the bare minimum required to run your application (glibc and ca-certificates), there are fewer components that could contain vulnerabilities
+- **Reduced Attack Surface**: By including only the bare minimum required to run your application (CA certificates, timezone data, and optionally glibc), there are fewer components that could contain vulnerabilities
 - **Compliance**: Many security standards and regulations require minimizing unnecessary software in production environments
 - **Smaller Images**: Minimal images mean faster pulls, reduced storage costs, and quicker deployments
 - **No Shell or Package Manager**: Without these tools, attackers have fewer options if they manage to breach your container
@@ -52,15 +52,17 @@ This declarative approach, inspired by Google Distroless and perfected by Chaing
   - Runs as a non-root user (`65532:65532`).
   - Automatically rebuilt daily to incorporate the latest security patches from upstream packages.
   - Images are signed with Cosign using keyless signing.
-  - A high-quality SBOM (Software Bill of Materials) is generated natively by `apko` during the build.
-- **CI/CD:** A streamlined GitHub Actions workflow using [`wolfi-act`](https://github.com/wolfi-dev/wolfi-act) handles the entire build, publish, and sign process in a single, efficient step.
+  - A high-quality SBOM (Software Bill of Materials) is generated natively by `apko` during the build and attached to each image as a signed in-registry attestation (`cosign attest --type spdxjson`).
+  - SLSA build provenance is attached to each image via GitHub artifact attestations.
+- **Reproducible:** Package versions are pinned in committed `apko lock` files (`base.lock.json`, `glibc.lock.json`, `debug.lock.json`) and image timestamps derive from the commit date (`SOURCE_DATE_EPOCH`), so rebuilding the same commit yields the same image. A daily workflow opens a PR when Wolfi package versions move.
+- **CI/CD:** A GitHub Actions workflow builds and publishes images under ephemeral run-scoped tags, tests and vulnerability-scans them, and only then signs, attests, and promotes the floating tags (`latest`, `glibc`, `debug`). An unscanned image is never reachable through a consumable tag.
 
 ## Image Variants
 
 This repository provides three distinct image variants to meet different use cases:
 
 ### Base Image (`:latest`)
-The default minimal distroless image with musl libc. This is the most minimal option suitable for statically-linked binaries or applications that don't require glibc.
+The default minimal distroless image. It ships no libc at all, making it the most minimal option, suitable for statically-linked binaries.
 
 ### glibc Image (`:glibc`)
 Extends the base image with GNU libc for maximum compatibility with dynamically-linked applications that expect glibc. Recommended for most applications requiring C library compatibility.
@@ -90,7 +92,7 @@ Use cases for the debug image:
 
 ### Available Image Tags
 
-**Base Production Image (musl libc):**
+**Base Production Image (static, no libc):**
 - `ghcr.io/taihen/base-image:latest` - Latest base image build
 - `ghcr.io/taihen/base-image:v2025.06.13` - Specific version tag
 
@@ -107,7 +109,7 @@ Use cases for the debug image:
 To build any variant using apko:
 
 ```sh
-# Build base image (musl libc)
+# Build base image (static, no libc)
 docker run -v $PWD:/work cgr.dev/chainguard/apko build base.yaml base:test base.tar
 docker load < base.tar
 
@@ -150,7 +152,7 @@ Together, apko and Wolfi provide a secure foundation for building container imag
 
 You can use these images as secure and minimal bases for your applications. Choose the appropriate variant based on your application's requirements:
 
-- Use `:latest` for statically-linked binaries or musl libc compatible apps
+- Use `:latest` for statically-linked binaries
 - Use `:glibc` for applications that require GNU libc compatibility  
 - Use `:debug` only for development and troubleshooting
 
@@ -173,7 +175,7 @@ USER 65532:65532
 ENTRYPOINT ["/hello"]
 ```
 
-### Example: Static Binary (musl libc)
+### Example: Static Binary (no libc)
 
 ```dockerfile  
 FROM golang:1.23-alpine AS builder
@@ -269,16 +271,42 @@ To build the image locally, you need Docker with BuildKit enabled.
 
 ## Automation
 
-The [`.github/workflows/build.yml`](./.github/workflows/build.yml) workflow handles the entire build, push, and sign process for all three image variants. It is triggered on:
+The [`.github/workflows/build.yml`](./.github/workflows/build.yml) workflow handles the entire build, test, sign, and publish process for all three image variants. It is triggered on:
 
 - A `push` to the `main` branch.
 - A daily schedule (`cron: "0 5 * * *"`) to ensure images are kept up-to-date with upstream packages.
 
-The workflow builds all three image variants in parallel and applies the following tagging strategy:
+The pipeline runs in stages so that no unscanned image is ever reachable through a consumable tag:
 
-- **Base images**: Tagged with `latest` and version tags (e.g., `v2025.06.13`)
-- **glibc images**: Tagged with `glibc` and version-glibc tags (e.g., `v2025.06.13-glibc`)
-- **Debug images**: Tagged with `debug` and version-debug tags (e.g., `v2025.06.13-debug`)
+1. **build** - builds each variant with `apko` (constrained by the committed lockfiles) and publishes it under an ephemeral run-scoped tag (`build-<run_id>-<variant>`).
+2. **test** - runs the Go smoke tests on both architectures and a Trivy vulnerability scan against the freshly built digests. Any failure stops the pipeline here.
+3. **promote** - signs each digest with Cosign (keyless), attaches the SPDX SBOM as a signed attestation and SLSA build provenance, then moves the floating tags:
+   - **Base images**: `latest` and version tags (e.g., `v2025.06.13`)
+   - **glibc images**: `glibc` and version-glibc tags (e.g., `v2025.06.13-glibc`)
+   - **Debug images**: `debug` and version-debug tags (e.g., `v2025.06.13-debug`)
+4. **release** - creates a GitHub release with version tags when package contents changed.
+
+The [`.github/workflows/update-locks.yml`](./.github/workflows/update-locks.yml) workflow regenerates the `apko lock` files daily and opens a PR when Wolfi package versions have moved, keeping builds reproducible while still tracking upstream security patches.
+
+### Verifying Images
+
+All artifacts are verifiable from the registry, without trusting this README:
+
+```bash
+IMAGE=ghcr.io/taihen/base-image:latest
+IDENTITY=https://github.com/taihen/base-image/.github/workflows/build.yml@refs/heads/main
+ISSUER=https://token.actions.githubusercontent.com
+
+# Signature
+cosign verify "$IMAGE" --certificate-identity="$IDENTITY" --certificate-oidc-issuer="$ISSUER"
+
+# SBOM attestation (SPDX)
+cosign verify-attestation "$IMAGE" --type spdxjson \
+  --certificate-identity="$IDENTITY" --certificate-oidc-issuer="$ISSUER"
+
+# SLSA build provenance
+gh attestation verify "oci://$IMAGE" --repo taihen/base-image
+```
 
 ## Automatic Release System
 
@@ -333,7 +361,7 @@ Before creating a release, the workflow runs comprehensive tests to ensure all t
 ### Test Suite
 
 1. **Go Application Test**: Builds and runs a hello world Go application on all three image variants
-   - Verifies glibc/musl compatibility as appropriate
+   - Verifies glibc/static-binary compatibility as appropriate
    - Tests both `linux/amd64` and `linux/arm64` architectures
    - Confirms correct user execution (UID 65532 for production variants, UID 0 for debug)
    - Validates environment variable handling

--- a/base.lock.json
+++ b/base.lock.json
@@ -1,0 +1,146 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "base.yaml",
+    "checksum": "sha256-t9mxgmd7Jv94/OCWIpShhCh+g4Ra8hqB07dvHwMBIOo="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5qQUHmzqX9oa/RS3OSgL\nYTYB1mzvVmnWC0JXsAafdgRkavJ9xRhsXMKXWPKMghZw6UnkxuxQCZlB9UhaFqed\nX7SWfQ8qRgECFmdGUjoeV7P3VUkg17RU0mUKsXZZF/2mU+jCGyk5eweKcLWrk6bn\nlNNF1vBJ9EXbHdfvbQsA5GfLku5tJhqRJ4FVQAGCw+1JoSKu+o3q+6xP7z6kMfR9\ncp54FSj48rTJUibbAv+cPtZ3AnbpjdyarV7SYMfxp14Q/KR0CJYDihG3CFoU+TaM\ndr7LUrgXaYw7m7g8hA2PY1jF8aqDqVFjVu/csPKnKVQSqNHfm4C4gljwT6TDVhPe\n6xKSGKfAUNvHx2RIqSsZJCh68Af+VnfuimbHMYzGhzV4/efihpJlYsDnOXJj/PeY\nSbEIYG2yoI3AYvDFyFX2OAOtQ9d4TPs4zS4aDg4R3UseXLib46FX3ZTfIi1/W0IO\neC3AFU5mK+02jq+7swcGbgzem30dFA/B3n8NQExJjF2WlGNJxFw2WnJQqKIkIh0s\nkm5jaxJ28xYgik+bEgxy1LsilKTowdkbEPRKv36JGdap4dOEGR+LwZsM+ontF1AO\nwY6tvwtZKJWhgj7ES3BdtiC1GA2htFnP90lA7KnKbSMOxwWtSCH8spitdPdzgI8G\nSxrOb0SZs6ZFAxYYe3GlvS0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2026c-r0.apk",
+        "version": "2026c-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5322",
+          "checksum": "sha1-D4uuAj8ilkc/B5+yge5Eeu9MAlc="
+        },
+        "data": {
+          "range": "bytes=5323-566945",
+          "checksum": "sha256-f0fSO8z0eGb12Ww/FSlqUouXdYUyQbFw8jhw5OB6EBk="
+        },
+        "checksum": "Q1D4uuAj8ilkc/B5+yge5Eeu9MAlc="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/aarch64/tzdata-2026c-r0.apk",
+        "version": "2026c-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5352",
+          "checksum": "sha1-lve/I2b+DtwlBgiwumn+UCbPFNQ="
+        },
+        "data": {
+          "range": "bytes=5353-566970",
+          "checksum": "sha256-APtIMWy/b2b7/1TgrcKxdVscdf1P0TysXvoQZttN2+M="
+        },
+        "checksum": "Q1lve/I2b+DtwlBgiwumn+UCbPFNQ="
+      }
+    ]
+  }
+}

--- a/debug.lock.json
+++ b/debug.lock.json
@@ -1,0 +1,640 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "debug.yaml",
+    "checksum": "sha256-iQEY2rnWH1wJfFr9uOeqU8L6XR7yhKOcwF4Xm/nmmgg="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5qQUHmzqX9oa/RS3OSgL\nYTYB1mzvVmnWC0JXsAafdgRkavJ9xRhsXMKXWPKMghZw6UnkxuxQCZlB9UhaFqed\nX7SWfQ8qRgECFmdGUjoeV7P3VUkg17RU0mUKsXZZF/2mU+jCGyk5eweKcLWrk6bn\nlNNF1vBJ9EXbHdfvbQsA5GfLku5tJhqRJ4FVQAGCw+1JoSKu+o3q+6xP7z6kMfR9\ncp54FSj48rTJUibbAv+cPtZ3AnbpjdyarV7SYMfxp14Q/KR0CJYDihG3CFoU+TaM\ndr7LUrgXaYw7m7g8hA2PY1jF8aqDqVFjVu/csPKnKVQSqNHfm4C4gljwT6TDVhPe\n6xKSGKfAUNvHx2RIqSsZJCh68Af+VnfuimbHMYzGhzV4/efihpJlYsDnOXJj/PeY\nSbEIYG2yoI3AYvDFyFX2OAOtQ9d4TPs4zS4aDg4R3UseXLib46FX3ZTfIi1/W0IO\neC3AFU5mK+02jq+7swcGbgzem30dFA/B3n8NQExJjF2WlGNJxFw2WnJQqKIkIh0s\nkm5jaxJ28xYgik+bEgxy1LsilKTowdkbEPRKv36JGdap4dOEGR+LwZsM+ontF1AO\nwY6tvwtZKJWhgj7ES3BdtiC1GA2htFnP90lA7KnKbSMOxwWtSCH8spitdPdzgI8G\nSxrOb0SZs6ZFAxYYe3GlvS0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13051",
+          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        },
+        "data": {
+          "range": "bytes=13052-147283",
+          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+        },
+        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13015",
+          "checksum": "sha1-npirsSp9Qt3Aa1n8CaC2i99nv8A="
+        },
+        "data": {
+          "range": "bytes=13016-89758",
+          "checksum": "sha256-qXzcGBEELIJays9BPEo77JB6Qr5gMKFbZteJHEuthAI="
+        },
+        "checksum": "Q1npirsSp9Qt3Aa1n8CaC2i99nv8A="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13257",
+          "checksum": "sha1-XSTHGW6PUOUepKQvlUCPEpu+my0="
+        },
+        "data": {
+          "range": "bytes=13258-3077429",
+          "checksum": "sha256-C538Z51QWuZPy/fxQGBCBbpulG8dVbn1OeaW+JsKoXQ="
+        },
+        "checksum": "Q1XSTHGW6PUOUepKQvlUCPEpu+my0="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2026c-r0.apk",
+        "version": "2026c-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5322",
+          "checksum": "sha1-D4uuAj8ilkc/B5+yge5Eeu9MAlc="
+        },
+        "data": {
+          "range": "bytes=5323-566945",
+          "checksum": "sha256-f0fSO8z0eGb12Ww/FSlqUouXdYUyQbFw8jhw5OB6EBk="
+        },
+        "checksum": "Q1D4uuAj8ilkc/B5+yge5Eeu9MAlc="
+      },
+      {
+        "name": "wolfi-keys",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-keys-1-r13.apk",
+        "version": "1-r13",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1527",
+          "checksum": "sha1-yen1tKh3ha5KrpU55DnYWyLHOQ0="
+        },
+        "data": {
+          "range": "bytes=1528-3879",
+          "checksum": "sha256-RQCwB014DXDQbJMoBV33+gvBVSpWGCpca41V5PgbuOQ="
+        },
+        "checksum": "Q1yen1tKh3ha5KrpU55DnYWyLHOQ0="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/x86_64/zlib-1.3.2-r3.apk",
+        "version": "1.3.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8782",
+          "checksum": "sha1-d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+        },
+        "data": {
+          "range": "bytes=8783-70985",
+          "checksum": "sha256-GtMaz7tc+6/gw51/jRq2trQH8bshZpL66etBeg87OHE="
+        },
+        "checksum": "Q1d+xgnhv2qmmnyUpkIEMLv/Ccfts="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10990",
+          "checksum": "sha1-8czJwPp28PlmrUy6evlca3lfXlk="
+        },
+        "data": {
+          "range": "bytes=10991-2439998",
+          "checksum": "sha256-Gtu+CyjMO2oH9qFjvJKo2t0zE0aDLG2dwtmDVnll8/4="
+        },
+        "checksum": "Q18czJwPp28PlmrUy6evlca3lfXlk="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/x86_64/libssl3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11000",
+          "checksum": "sha1-cfdB5BXNoGxB998AA6UNEUQzmG4="
+        },
+        "data": {
+          "range": "bytes=11001-524305",
+          "checksum": "sha256-VtGnoMNcs4UcJxBfFv47/vmpWT2kz+LXfzmLFrDzndQ="
+        },
+        "checksum": "Q1cfdB5BXNoGxB998AA6UNEUQzmG4="
+      },
+      {
+        "name": "apk-tools",
+        "url": "https://packages.wolfi.dev/os/x86_64/apk-tools-2.14.10-r13.apk",
+        "version": "2.14.10-r13",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9161",
+          "checksum": "sha1-zJfYXvHjFDcd80CYqTq/nIlmXgY="
+        },
+        "data": {
+          "range": "bytes=9162-187797",
+          "checksum": "sha256-lLGQ8srdb05C5FUmcibNbSuMDbVLsPPNPDjAkrYrkAI="
+        },
+        "checksum": "Q1zJfYXvHjFDcd80CYqTq/nIlmXgY="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/x86_64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8536",
+          "checksum": "sha1-I0YlF5JXljMqn3nnsq4AWUw6X/8="
+        },
+        "data": {
+          "range": "bytes=8537-106099",
+          "checksum": "sha256-mzRytDzhPafMZpD3kpn03C6x2XCNuG0nZ1F3Bjo+Jx4="
+        },
+        "checksum": "Q1I0YlF5JXljMqn3nnsq4AWUw6X/8="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/x86_64/libcrypt1-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13067",
+          "checksum": "sha1-/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+        },
+        "data": {
+          "range": "bytes=13068-14685",
+          "checksum": "sha256-ePacrwddp1Us3l5Rg2i8ieOZi17FUQjiVMtw2syPQBE="
+        },
+        "checksum": "Q1/MS3Zb1Y/+sboqr3bltHEFCEkqE="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/x86_64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10913",
+          "checksum": "sha1-Dc1coU0swhMsnFh4BnVin4Y/z6U="
+        },
+        "data": {
+          "range": "bytes=10914-430452",
+          "checksum": "sha256-Lp5skr4+yaxDhdl+G39Z7VC8YLLcwNh+fGvRe0T6bj0="
+        },
+        "checksum": "Q1Dc1coU0swhMsnFh4BnVin4Y/z6U="
+      },
+      {
+        "name": "wolfi-base",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-base-1-r7.apk",
+        "version": "1-r7",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-838",
+          "checksum": "sha1-6Ctc7TvokDUPOi+0TkHCeSmryh0="
+        },
+        "data": {
+          "range": "bytes=839-1815",
+          "checksum": "sha256-7GMNwlnLai87gKlJ/itO/ssJ0+99pHkBNDPfG5C+Q/I="
+        },
+        "checksum": "Q16Ctc7TvokDUPOi+0TkHCeSmryh0="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9968",
+          "checksum": "sha1-0/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+        },
+        "data": {
+          "range": "bytes=9969-86427",
+          "checksum": "sha256-ECrE4xEgBQV3df1UklKqzMzpglmWfjLg9FsjCGK05lc="
+        },
+        "checksum": "Q10/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13058",
+          "checksum": "sha1-BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+        },
+        "data": {
+          "range": "bytes=13059-89800",
+          "checksum": "sha256-CY8DYMdTEZQDdr0V9mSZy6OO+DzjhmSBZSD4dF/nK5s="
+        },
+        "checksum": "Q1BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13092",
+          "checksum": "sha1-vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+        },
+        "data": {
+          "range": "bytes=13093-125752",
+          "checksum": "sha256-S1pHeMAxoXQpYYtqlbDdPoKu7tt5flTCAms4yNZv6NI="
+        },
+        "checksum": "Q1vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13295",
+          "checksum": "sha1-iNjpwJYrlEf1vRh127vhMVvg6TI="
+        },
+        "data": {
+          "range": "bytes=13296-2235744",
+          "checksum": "sha256-K/MWiiI44ynr5ZGr3okL8Axmy+4VArr8y5zH6DYDRuk="
+        },
+        "checksum": "Q1iNjpwJYrlEf1vRh127vhMVvg6TI="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/aarch64/tzdata-2026c-r0.apk",
+        "version": "2026c-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5352",
+          "checksum": "sha1-lve/I2b+DtwlBgiwumn+UCbPFNQ="
+        },
+        "data": {
+          "range": "bytes=5353-566970",
+          "checksum": "sha256-APtIMWy/b2b7/1TgrcKxdVscdf1P0TysXvoQZttN2+M="
+        },
+        "checksum": "Q1lve/I2b+DtwlBgiwumn+UCbPFNQ="
+      },
+      {
+        "name": "wolfi-keys",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-keys-1-r13.apk",
+        "version": "1-r13",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1547",
+          "checksum": "sha1-MfuXifUsiF7Gi6pYnIuTfJM+2tk="
+        },
+        "data": {
+          "range": "bytes=1548-3899",
+          "checksum": "sha256-wnIMFE1eYGoM7pHGJm/SmJ3s7j4F7ZQJDS6ohU7u+Ss="
+        },
+        "checksum": "Q1MfuXifUsiF7Gi6pYnIuTfJM+2tk="
+      },
+      {
+        "name": "zlib",
+        "url": "https://packages.wolfi.dev/os/aarch64/zlib-1.3.2-r3.apk",
+        "version": "1.3.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8828",
+          "checksum": "sha1-YxX5T6R79BRPOcEnMqh9dQy7E3c="
+        },
+        "data": {
+          "range": "bytes=8829-60677",
+          "checksum": "sha256-ij7mAZJowteCp2WSpbbgRHBrOgQgSAOzkQJnpjb2xoQ="
+        },
+        "checksum": "Q1YxX5T6R79BRPOcEnMqh9dQy7E3c="
+      },
+      {
+        "name": "libcrypto3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypto3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11026",
+          "checksum": "sha1-IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+        },
+        "data": {
+          "range": "bytes=11027-2210037",
+          "checksum": "sha256-Z8qrYFVxk9L0+ZpEpIV/yFNFZwBgRHR+W4OPv/UJY1k="
+        },
+        "checksum": "Q1IhlZQ3XyVyqnes8zsNjtdfcdEO0="
+      },
+      {
+        "name": "libssl3",
+        "url": "https://packages.wolfi.dev/os/aarch64/libssl3-3.6.3-r3.apk",
+        "version": "3.6.3-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-11031",
+          "checksum": "sha1-b1pa5Bgcwm18pYPDH0t+0fM/OXw="
+        },
+        "data": {
+          "range": "bytes=11032-489215",
+          "checksum": "sha256-Ba2zY8Skdb0ILJ0vTo3C4nxRvw/Y5SOoYAvILmBcOhE="
+        },
+        "checksum": "Q1b1pa5Bgcwm18pYPDH0t+0fM/OXw="
+      },
+      {
+        "name": "apk-tools",
+        "url": "https://packages.wolfi.dev/os/aarch64/apk-tools-2.14.10-r13.apk",
+        "version": "2.14.10-r13",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9192",
+          "checksum": "sha1-BKmmk21n/IcPWpzWAvKjPjgHC2o="
+        },
+        "data": {
+          "range": "bytes=9193-180087",
+          "checksum": "sha256-wz870qoGqxIk6t5YIcsclb+Ebuxm2cAj8+e0uBawjHc="
+        },
+        "checksum": "Q1BKmmk21n/IcPWpzWAvKjPjgHC2o="
+      },
+      {
+        "name": "libxcrypt",
+        "url": "https://packages.wolfi.dev/os/aarch64/libxcrypt-4.5.2-r3.apk",
+        "version": "4.5.2-r3",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-8572",
+          "checksum": "sha1-ghgqrJg4iSn9gnlkDzpWMPFaymg="
+        },
+        "data": {
+          "range": "bytes=8573-104313",
+          "checksum": "sha256-XizRWLvfUizHwKzjGLYIFKzfDDehNmTY9yPgDFlLPS4="
+        },
+        "checksum": "Q1ghgqrJg4iSn9gnlkDzpWMPFaymg="
+      },
+      {
+        "name": "libcrypt1",
+        "url": "https://packages.wolfi.dev/os/aarch64/libcrypt1-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13111",
+          "checksum": "sha1-Lc5RMEoBlR4TAJtUNiw9hlafq2g="
+        },
+        "data": {
+          "range": "bytes=13112-14724",
+          "checksum": "sha256-miwdByMJn6F2TDvzLLhMazBsP7eTM9okMUmceXVUaxM="
+        },
+        "checksum": "Q1Lc5RMEoBlR4TAJtUNiw9hlafq2g="
+      },
+      {
+        "name": "busybox",
+        "url": "https://packages.wolfi.dev/os/aarch64/busybox-1.37.0-r61.apk",
+        "version": "1.37.0-r61",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-10947",
+          "checksum": "sha1-EeHjQ8oI9CX5Am00/gUwayfeglc="
+        },
+        "data": {
+          "range": "bytes=10948-429972",
+          "checksum": "sha256-TdoIXtUKXr9KtXVi4OBLcI3jzrea4+YQha1GxArzayI="
+        },
+        "checksum": "Q1EeHjQ8oI9CX5Am00/gUwayfeglc="
+      },
+      {
+        "name": "wolfi-base",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-base-1-r7.apk",
+        "version": "1-r7",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-868",
+          "checksum": "sha1-+0E0UlaxkLWVTbmu8bjwYXhbZjo="
+        },
+        "data": {
+          "range": "bytes=869-1846",
+          "checksum": "sha256-TqlPNjoa6bGQA8wvXJmlTmWUszMn91JjPSYJvdMavsE="
+        },
+        "checksum": "Q1+0E0UlaxkLWVTbmu8bjwYXhbZjo="
+      }
+    ]
+  }
+}

--- a/glibc.lock.json
+++ b/glibc.lock.json
@@ -1,0 +1,298 @@
+{
+  "version": "v1",
+  "config": {
+    "name": "glibc.yaml",
+    "checksum": "sha256-CgGEFneE8Qq4Q9+MpyTT0CTolP74TubYUqOjL3ppX1A="
+  },
+  "contents": {
+    "keyring": [
+      {
+        "name": "packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "url": "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+        "content": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5qQUHmzqX9oa/RS3OSgL\nYTYB1mzvVmnWC0JXsAafdgRkavJ9xRhsXMKXWPKMghZw6UnkxuxQCZlB9UhaFqed\nX7SWfQ8qRgECFmdGUjoeV7P3VUkg17RU0mUKsXZZF/2mU+jCGyk5eweKcLWrk6bn\nlNNF1vBJ9EXbHdfvbQsA5GfLku5tJhqRJ4FVQAGCw+1JoSKu+o3q+6xP7z6kMfR9\ncp54FSj48rTJUibbAv+cPtZ3AnbpjdyarV7SYMfxp14Q/KR0CJYDihG3CFoU+TaM\ndr7LUrgXaYw7m7g8hA2PY1jF8aqDqVFjVu/csPKnKVQSqNHfm4C4gljwT6TDVhPe\n6xKSGKfAUNvHx2RIqSsZJCh68Af+VnfuimbHMYzGhzV4/efihpJlYsDnOXJj/PeY\nSbEIYG2yoI3AYvDFyFX2OAOtQ9d4TPs4zS4aDg4R3UseXLib46FX3ZTfIi1/W0IO\neC3AFU5mK+02jq+7swcGbgzem30dFA/B3n8NQExJjF2WlGNJxFw2WnJQqKIkIh0s\nkm5jaxJ28xYgik+bEgxy1LsilKTowdkbEPRKv36JGdap4dOEGR+LwZsM+ontF1AO\nwY6tvwtZKJWhgj7ES3BdtiC1GA2htFnP90lA7KnKbSMOxwWtSCH8spitdPdzgI8G\nSxrOb0SZs6ZFAxYYe3GlvS0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
+      }
+    ],
+    "build_repositories": [],
+    "runtime_repositories": [],
+    "repositories": [
+      {
+        "name": "packages.wolfi.dev/os/x86_64",
+        "url": "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz",
+        "architecture": "x86_64"
+      },
+      {
+        "name": "packages.wolfi.dev/os/aarch64",
+        "url": "https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz",
+        "architecture": "aarch64"
+      }
+    ],
+    "packages": [
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1932",
+          "checksum": "sha1-mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+        },
+        "data": {
+          "range": "bytes=1933-13952",
+          "checksum": "sha256-5jOBVeXTWJEbL+Cnxj5Nu4klEL4SEB7IDMzT96rbkkA="
+        },
+        "checksum": "Q1mxVgkD4+r1cSUSeWo6ClkgNR1IA="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/x86_64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7872",
+          "checksum": "sha1-KyCdEL20IKE+B7DKW97GLXu2QLM="
+        },
+        "data": {
+          "range": "bytes=7873-137518",
+          "checksum": "sha256-foyxNKCWc3UQM3Kq5on+Gt/2d+HlzCUl+1lqiaviWE8="
+        },
+        "checksum": "Q1KyCdEL20IKE+B7DKW97GLXu2QLM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/x86_64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13051",
+          "checksum": "sha1-Dc94e4JF2fG8/SX4PWCAtLjItu4="
+        },
+        "data": {
+          "range": "bytes=13052-147283",
+          "checksum": "sha256-oI72DIuJLqlUM/LSFYKdgbxsaYUZgfThezkV95CHQPk="
+        },
+        "checksum": "Q1Dc94e4JF2fG8/SX4PWCAtLjItu4="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9951",
+          "checksum": "sha1-v4FvRKA29cOT2WtAXaWZBCzRXaU="
+        },
+        "data": {
+          "range": "bytes=9952-105490",
+          "checksum": "sha256-ExYZSr5G/sH+fzFe+TjVUTTj/GQ1Qbjx8MMEh+6ZxE0="
+        },
+        "checksum": "Q1v4FvRKA29cOT2WtAXaWZBCzRXaU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13015",
+          "checksum": "sha1-npirsSp9Qt3Aa1n8CaC2i99nv8A="
+        },
+        "data": {
+          "range": "bytes=13016-89758",
+          "checksum": "sha256-qXzcGBEELIJays9BPEo77JB6Qr5gMKFbZteJHEuthAI="
+        },
+        "checksum": "Q1npirsSp9Qt3Aa1n8CaC2i99nv8A="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/x86_64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13257",
+          "checksum": "sha1-XSTHGW6PUOUepKQvlUCPEpu+my0="
+        },
+        "data": {
+          "range": "bytes=13258-3077429",
+          "checksum": "sha256-C538Z51QWuZPy/fxQGBCBbpulG8dVbn1OeaW+JsKoXQ="
+        },
+        "checksum": "Q1XSTHGW6PUOUepKQvlUCPEpu+my0="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/x86_64/tzdata-2026c-r0.apk",
+        "version": "2026c-r0",
+        "architecture": "x86_64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5322",
+          "checksum": "sha1-D4uuAj8ilkc/B5+yge5Eeu9MAlc="
+        },
+        "data": {
+          "range": "bytes=5323-566945",
+          "checksum": "sha256-f0fSO8z0eGb12Ww/FSlqUouXdYUyQbFw8jhw5OB6EBk="
+        },
+        "checksum": "Q1D4uuAj8ilkc/B5+yge5Eeu9MAlc="
+      },
+      {
+        "name": "wolfi-baselayout",
+        "url": "https://packages.wolfi.dev/os/aarch64/wolfi-baselayout-20230201-r29.apk",
+        "version": "20230201-r29",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-1962",
+          "checksum": "sha1-FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+        },
+        "data": {
+          "range": "bytes=1963-13980",
+          "checksum": "sha256-jYse4NUqE3SQbsor532PGqEhuLikUOl38/yf1PJA1nY="
+        },
+        "checksum": "Q1FcjlR8BAUcyRjMQxsc/f5gWSv8I="
+      },
+      {
+        "name": "ca-certificates-bundle",
+        "url": "https://packages.wolfi.dev/os/aarch64/ca-certificates-bundle-20260413-r0.apk",
+        "version": "20260413-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-7907",
+          "checksum": "sha1-YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+        },
+        "data": {
+          "range": "bytes=7908-137552",
+          "checksum": "sha256-1NKuKrCJxco8aTxdlzNkEjM/4HyDXmO6sGOfSTiu8aE="
+        },
+        "checksum": "Q1YLGEH8o/PNCjR8sxoxh//AGpOgQ="
+      },
+      {
+        "name": "libgcc",
+        "url": "https://packages.wolfi.dev/os/aarch64/libgcc-16.1.0-r4.apk",
+        "version": "16.1.0-r4",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-9968",
+          "checksum": "sha1-0/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+        },
+        "data": {
+          "range": "bytes=9969-86427",
+          "checksum": "sha256-ECrE4xEgBQV3df1UklKqzMzpglmWfjLg9FsjCGK05lc="
+        },
+        "checksum": "Q10/N/tQIIDrAIbJ8QA8/iMB2bmfU="
+      },
+      {
+        "name": "glibc-locale-posix",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-locale-posix-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13058",
+          "checksum": "sha1-BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+        },
+        "data": {
+          "range": "bytes=13059-89800",
+          "checksum": "sha256-CY8DYMdTEZQDdr0V9mSZy6OO+DzjhmSBZSD4dF/nK5s="
+        },
+        "checksum": "Q1BIBCJGNefQ6OZhfH+yQAL1S3/bM="
+      },
+      {
+        "name": "ld-linux",
+        "url": "https://packages.wolfi.dev/os/aarch64/ld-linux-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13092",
+          "checksum": "sha1-vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+        },
+        "data": {
+          "range": "bytes=13093-125752",
+          "checksum": "sha256-S1pHeMAxoXQpYYtqlbDdPoKu7tt5flTCAms4yNZv6NI="
+        },
+        "checksum": "Q1vqCKIZcxA7Bw0Sdk31ANMcX7SkE="
+      },
+      {
+        "name": "glibc",
+        "url": "https://packages.wolfi.dev/os/aarch64/glibc-2.43-r11.apk",
+        "version": "2.43-r11",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-13295",
+          "checksum": "sha1-iNjpwJYrlEf1vRh127vhMVvg6TI="
+        },
+        "data": {
+          "range": "bytes=13296-2235744",
+          "checksum": "sha256-K/MWiiI44ynr5ZGr3okL8Axmy+4VArr8y5zH6DYDRuk="
+        },
+        "checksum": "Q1iNjpwJYrlEf1vRh127vhMVvg6TI="
+      },
+      {
+        "name": "tzdata",
+        "url": "https://packages.wolfi.dev/os/aarch64/tzdata-2026c-r0.apk",
+        "version": "2026c-r0",
+        "architecture": "aarch64",
+        "signature": {
+          "range": "",
+          "checksum": ""
+        },
+        "control": {
+          "range": "bytes=0-5352",
+          "checksum": "sha1-lve/I2b+DtwlBgiwumn+UCbPFNQ="
+        },
+        "data": {
+          "range": "bytes=5353-566970",
+          "checksum": "sha256-APtIMWy/b2b7/1TgrcKxdVscdf1P0TysXvoQZttN2+M="
+        },
+        "checksum": "Q1lve/I2b+DtwlBgiwumn+UCbPFNQ="
+      }
+    ]
+  }
+}

--- a/scripts/compare_sboms.py
+++ b/scripts/compare_sboms.py
@@ -2,6 +2,8 @@ import json
 import os
 import sys
 
+VARIANTS = ['base', 'glibc', 'debug']
+
 def get_sbom_files(directory, prefix):
     sbom_files = []
     if not os.path.exists(directory):
@@ -14,6 +16,9 @@ def get_sbom_files(directory, prefix):
     return sbom_files
 
 def parse_sboms(paths):
+    # apko emits SPDX SBOMs: package entries live under 'packages' with
+    # 'versionInfo'. The index SBOM has no package list and contributes
+    # nothing here; per-arch SBOMs carry the actual packages.
     packages = {}
     for path in paths:
         if not os.path.exists(path):
@@ -21,80 +26,53 @@ def parse_sboms(paths):
         with open(path, 'r') as f:
             try:
                 sbom = json.load(f)
-                # Support both 'components' (new) and 'packages' (old)
-                component_list = sbom.get('components')
-                if component_list is None:
-                    component_list = sbom.get('packages')
-                
-                if component_list:
-                    for component in component_list:
-                        name = component.get('name', 'unknown')
-                        # Support both 'version' (new) and 'versionInfo' (old)
-                        version = component.get('version')
-                        if version is None:
-                            version = component.get('versionInfo', 'unknown')
-                        packages[name] = version
             except json.JSONDecodeError:
                 print(f"Warning: Could not decode JSON from {path}")
+                continue
+        for package in sbom.get('packages') or []:
+            name = package.get('name', 'unknown')
+            packages[name] = package.get('versionInfo', 'unknown')
     return packages
 
 def compare_packages(old_pkgs, new_pkgs):
-    if not old_pkgs and not new_pkgs:
-        return False
-    if not old_pkgs and new_pkgs:
+    if not old_pkgs:
         print("No previous SBOM found. Assuming changes.")
         return True
     return old_pkgs != new_pkgs
 
 def main():
-    # Check for both old (main) and new (base) naming
-    prev_base_files = get_sbom_files('previous-sbom', 'base_')
-    prev_main_files = get_sbom_files('previous-sbom', 'main_')  # backward compatibility
-    prev_glibc_files = get_sbom_files('previous-sbom', 'glibc_')
-    prev_debug_files = get_sbom_files('previous-sbom', 'debug_')
-    
-    curr_base_files = get_sbom_files('sbom-output', 'base_')
-    curr_glibc_files = get_sbom_files('sbom-output', 'glibc_')
-    curr_debug_files = get_sbom_files('sbom-output', 'debug_')
-    
-    print(f"Previous base SBOMs: {prev_base_files}")
-    print(f"Previous main SBOMs: {prev_main_files}")
-    print(f"Previous glibc SBOMs: {prev_glibc_files}")
-    print(f"Previous debug SBOMs: {prev_debug_files}")
-    print(f"Current base SBOMs: {curr_base_files}")
-    print(f"Current glibc SBOMs: {curr_glibc_files}")
-    print(f"Current debug SBOMs: {curr_debug_files}")
-    
-    # Parse previous packages (use main_ files as fallback for base if no base_ files exist)
-    prev_base_pkgs = parse_sboms(prev_base_files if prev_base_files else prev_main_files)
-    prev_glibc_pkgs = parse_sboms(prev_glibc_files)
-    prev_debug_pkgs = parse_sboms(prev_debug_files)
-    
-    # Parse current packages
-    curr_base_pkgs = parse_sboms(curr_base_files)
-    curr_glibc_pkgs = parse_sboms(curr_glibc_files)
-    curr_debug_pkgs = parse_sboms(curr_debug_files)
-    
-    # Compare packages
-    base_changed = compare_packages(prev_base_pkgs, curr_base_pkgs)
-    glibc_changed = compare_packages(prev_glibc_pkgs, curr_glibc_pkgs)
-    debug_changed = compare_packages(prev_debug_pkgs, curr_debug_pkgs)
-    
-    if base_changed:
-        print("Base SBOM has changes.")
-    if glibc_changed:
-        print("glibc SBOM has changes.")
-    if debug_changed:
-        print("Debug SBOM has changes.")
-    
-    if base_changed or glibc_changed or debug_changed:
+    changed = False
+    for variant in VARIANTS:
+        curr_files = get_sbom_files('sbom-output', f'{variant}_')
+        prev_files = get_sbom_files('previous-sbom', f'{variant}_')
+        if variant == 'base' and not prev_files:
+            # backward compatibility with the old 'main_' prefix
+            prev_files = get_sbom_files('previous-sbom', 'main_')
+
+        print(f"Previous {variant} SBOMs: {prev_files}")
+        print(f"Current {variant} SBOMs: {curr_files}")
+
+        # Fail closed: a missing or empty current SBOM is a build defect,
+        # not "no change".
+        if not curr_files:
+            print(f"ERROR: no current SBOM files found for {variant}.")
+            sys.exit(1)
+        curr_pkgs = parse_sboms(curr_files)
+        if not curr_pkgs:
+            print(f"ERROR: current {variant} SBOMs contain no packages.")
+            sys.exit(1)
+
+        prev_pkgs = parse_sboms(prev_files)
+        if compare_packages(prev_pkgs, curr_pkgs):
+            print(f"{variant} SBOM has changes.")
+            changed = True
+
+    if changed:
         print("Changes detected in SBOMs.")
-        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            f.write('sbom-changes=true\n')
     else:
         print("No changes detected in SBOMs.")
-        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            f.write('sbom-changes=false\n')
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+        f.write(f"sbom-changes={'true' if changed else 'false'}\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes the supply chain gaps found when comparing this repo against the base image evaluation criteria: the SBOM only lived in CI artifacts instead of the registry, there was no build provenance, and `:latest` could point at an image that had not been scanned yet (publish and sign ran before Trivy).

The build flow is now staged:

1. `build` publishes each variant under an ephemeral `build-<run_id>-<variant>` tag, unsigned
2. `test` runs the smoke tests and Trivy against those digests
3. `promote` (new job) signs with cosign, attaches the SPDX SBOM as an attestation, attaches SLSA build provenance, and only then moves `latest` / `glibc` / `debug`
4. `release` adds version tags as before

So a bad image can still get built, but it can never be reached through a tag anyone consumes.

Other changes:

- Package versions are pinned in committed apko lockfiles. A new daily workflow regenerates them and opens a PR when Wolfi package versions move. Together with `SOURCE_DATE_EPOCH` taken from the commit date, rebuilding the same commit now gives the same image.
- All actions are pinned to commit SHAs, including trivy-action which was on `@master`.
- `compare_sboms.py` now fails the build when a current SBOM is missing or empty, instead of treating it as "no change". Also dropped the CycloneDX parsing branch, apko only emits SPDX.
- README corrections: the base variant ships no libc at all (Wolfi is glibc based, there is no musl anywhere in this repo), and the wolfi-act mention was stale since the workflow never used it. Added instructions for verifying the signature, the SBOM attestation and the provenance.
- apko 1.2.8 -> 1.2.25, matching the version used to generate the lockfiles.
- Fixed the workflow_call ref lookup: `github.event.inputs.ref` is always empty in a called workflow, it needs `inputs.ref`.

The promote job has not run in CI yet, the first run on main will prove out the attestation steps and the SBOM predicate paths.

Known follow-ups, kept out of this PR:

- ephemeral `build-*` tags accumulate in GHCR and need a cleanup job or retention policy
- lock bump PRs are opened with `GITHUB_TOKEN`, so PR validation will not trigger on them by itself